### PR TITLE
Update key_grabber.c

### DIFF
--- a/src/key_grabber.c
+++ b/src/key_grabber.c
@@ -131,7 +131,7 @@ void tilda_window_set_active (tilda_window *tw)
 
     XEvent event;
     long mask = SubstructureRedirectMask | SubstructureNotifyMask;
-
+    gtk_window_move (GTK_WINDOW(tw->window), config_getint ("x_pos"), config_getint ("y_pos"));
     if (gdk_x11_screen_supports_net_wm_hint (screen,
                                              gdk_atom_intern_static_string ("_NET_ACTIVE_WINDOW")))
     {


### PR DESCRIPTION
Fixed issue with window dropping down on monitor #2 and staying there until opening configuration and adjusting an X/Y value which caused the window to snap back to the correct location. Added this movement code to the activate function which fixed the issue for me.

Now when I mouse into monitor number 2 and press the activate hotkey, the tilda console pops down on the left screen (monitor 1) where as before this patch it would open at (0,0) on the 2nd monitor which was not the desired behavior..  I wouldn't have minded much if moving the mouse back to monitor 1 and repeating the activate hotkey would move it back but somehow it didn't and tilda remained "stuck" on monitor 2. 

Thanks for the hard work on Tilda, I love this tool. 
